### PR TITLE
feat: add Redis to Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       - 5469:5432 # Exposing 5469 for development. Should remove in production.
     volumes:
       - timescale_data:/var/lib/postgresql/data
-
+  redis:
+    image: redis:7-alpine
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_cache:/data
 volumes:
   timescale_data:
+  redis_cache:


### PR DESCRIPTION
Redis image added to Docker Compose file so we can use Redis server to back the message queue for use by ingestion express app and parsing/transformation workers.