### PR TITLE
feat: added basic grok parsing to vector shipper

### DIFF
--- a/vector/vector-shipper.yaml
+++ b/vector/vector-shipper.yaml
@@ -10,11 +10,38 @@ sources:
       condition_pattern: '^\['  # Optional: Condition pattern for multiline aggregation
       timeout_ms: 1000  # Optional: Timeout for multiline aggregation
 
+transforms:
+  parse_logs:
+    type: remap
+    inputs:
+      - app_logs
+    source: |
+      # Parse the log line using the Grok pattern
+      parsed, err = parse_grok(.message, "%{IP:client} - - \\[%{TIMESTAMP_ISO8601:timestamp}\\] \\\"%{WORD:method} %{PATH:path} HTTP/%{NUMBER:http_version}\\\" %{NUMBER:status} %{NUMBER:bytes} \\\"%{URI:referrer}\\\" \\\"%{DATA:user_agent}\\\"")
+      
+      # Handle errors (e.g., if the log line doesn't match the pattern)
+      if err != null {
+        log("Failed to parse log line: " + string!(err), level: "error")
+      } else {
+        # Merge the parsed fields into the event
+        . = merge(., parsed)
+
+        # Extract the "level" from the "path" field
+        if .path == "/" {
+          .level = "info"
+        } else {
+          .level = split(.path, "/")[1] ?? "unknown"
+        }
+
+        # Remove the "path" field
+        del(.path)
+      }
+
 sinks:
   kafka:
     type: kafka
     inputs:
-      - app_logs
+      - parse_logs
     bootstrap_servers: broker:29092
     topic: app_logs_topic
     encoding:


### PR DESCRIPTION
Example:

Received log from Kafka: {
  bytes: '2326',
  client: '127.0.0.1',
  file: '/logs/app.log',
  host: 'cbb005457ade',
  http_version: '1.1',
  level: 'error',
  message: '127.0.0.1 - - [2025-03-20T21:19:04.643Z] "GET /error HTTP/1.1" 500 2326 "http://example.com" "Mozilla/5.0"',
  method: 'GET',
  referrer: 'http://example.com',
  source_type: 'file',
  status: '500',
  timestamp: '2025-03-20T21:19:04.643Z',
  user_agent: 'Mozilla/5.0'
}