### PR TITLE
fix: vector consumer yaml changed to fix json parsing. apachelogger n…

### DIFF
--- a/apacheLogger/vector-shipper.yaml
+++ b/apacheLogger/vector-shipper.yaml
@@ -10,8 +10,8 @@ transforms:
     inputs:
       - app_logs
     source: |
-      # Parse the log line using the Grok pattern
-      parsed, err = parse_grok(.message, "%{IP:client} - - \\[%{TIMESTAMP_ISO8601:timestamp}\\] \\\"%{WORD:method} %{PATH:path} HTTP/%{NUMBER:http_version}\\\" %{NUMBER:status} %{NUMBER:bytes} \\\"%{URI:referrer}\\\" \\\"%{DATA:user_agent}\\\"")
+      # Parse the log line using Apache combined format
+      parsed, err = parse_apache_log(.message, "combined", "%Y-%m-%dT%H:%M:%S.%fZ")
       
       # Handle errors (e.g., if the log line doesn't match the pattern)
       if err != null {
@@ -26,9 +26,6 @@ transforms:
         } else {
           .level = split(.path, "/")[1] ?? "unknown"
         }
-
-        # Remove the "path" field
-        del(.path)
       }
 
 sinks:

--- a/vector/vector-consumer.yaml
+++ b/vector/vector-consumer.yaml
@@ -6,11 +6,19 @@ sources:
     topics:
       - app_logs_topic
 
+transforms:
+  parse_json:
+    type: remap
+    inputs:
+      - kafka
+    source: |
+      . = parse_json!(.message)
+
 sinks:
   loki:
     type: loki
     inputs:
-      - kafka
+      - parse_json  # Use the transformed logs
     endpoint: http://loki:3100
     labels:
       agent: vector


### PR DESCRIPTION
…ow uses apache parsing

Overview

- Grok parsing removed from apacheLogger vector shipper.
- Native apache parsing now being used 
- Vector consumer now doing transformation to make sure loki receives correct JSON object.

Testing

- `docker compose down -v`  and `docker compose up -d` the vector shippers and unilogs docker compose files
- Check grafana is displaying correct JSON objects when receiving logs.

JSON example:

{
  "agent": "Mozilla/5.0",
  "file": "/logs/app.log",
  "host": "127.0.0.1",
  "level": "error",
  "message": "GET /error HTTP/1.1",
  "method": "GET",
  "path": "/error",
  "protocol": "HTTP/1.1",
  "referrer": "http://example.com",
  "size": 2326,
  "source_type": "file",
  "status": 500
}