### PR TITLE
Now able to make custom labels in our pipeline

### DIFF
--- a/plaintextLogger/vector-shipper.yaml
+++ b/plaintextLogger/vector-shipper.yaml
@@ -15,7 +15,7 @@ transforms:
 
       # Parse the log line using the Grok pattern
       parsed, err = parse_grok(.message, "\\[%{LOGLEVEL:level}\\] %{GREEDYDATA:message} at %{TIMESTAMP_ISO8601:timestamp}")
-      
+
       # Handle errors (e.g., if the log line doesn't match the pattern)
       if err != null {
         log("Failed to parse log line: " + string!(err), level: "error")
@@ -29,6 +29,8 @@ transforms:
         # Timestamp is captured as `timestamp`
       }
 
+      # Testing
+      .uni_logs_label="test"
 
 sinks:
   kafka:
@@ -39,7 +41,7 @@ sinks:
     topic: app_logs_topic
     encoding:
       codec: json
-  
+
   console:
     type: console
     inputs:

--- a/vector/vector-consumer.yaml
+++ b/vector/vector-consumer.yaml
@@ -13,14 +13,16 @@ transforms:
       - kafka
     source: |
       . = parse_json!(.message)
+      .test_label = .uni_logs_label
 
 sinks:
   loki:
     type: loki
     inputs:
-      - parse_json  # Use the transformed logs
+      - parse_json # Use the transformed logs
     endpoint: http://loki:3100
     labels:
+      unilogs: '{{ test_label }}'
       agent: vector
     encoding:
       codec: json


### PR DESCRIPTION
PROBLEM:

* Couldn't set custom labels if the shippers were ingesting directly into loki, now we can.

HOW TO TEST:

    * Start the logging applications, `apacheLogger`, `plaintextLogger`, with `npm start`
    * docker compose up the unilogs project
    * docker compose up the log shippers
    * Go to Grafana on http://localhost:3000/
    * Go to Explore -> logs and see if `unilogs` pop up if you click the `Add label` button above the graphs.
