### PR TITLE
56 make grafana use persistent volumes

### DIFF
--- a/values/grafana_values.yaml
+++ b/values/grafana_values.yaml
@@ -1,0 +1,21 @@
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki-gateway.loki.svc.cluster.local/
+        isDefault: true
+        basicAuth: true
+        jsonData:
+          httpHeaderName1: 'Authorization'
+          httpHeaderName2: 'X-Scope-OrgId' # Define the custom header key
+        secureJsonData:
+          httpHeaderValue1: 'Basic YWRtaW46c2VjcmV0' # `echo -n "admin:secret" | base64`
+          httpHeaderValue2: 'default' # Define the header value
+persistence:
+  enabled: true
+  type: pvc
+  size: 1Gi
+  storageClassName: gp2

--- a/values/loki_values.yaml
+++ b/values/loki_values.yaml
@@ -54,7 +54,7 @@ serviceAccount:
     'eks.amazonaws.com/role-arn': 'arn:aws:iam::<Account ID>:role/LokiServiceAccountRole' # The service role you created
 
 deploymentMode: SimpleScalable
-
+# Holdovers from 
 # ingester:
 #   replicas: 3
 #   zoneAwareReplication:

--- a/values/loki_values.yaml
+++ b/values/loki_values.yaml
@@ -121,7 +121,7 @@ backend:
     storageClass: gp2
     size: 1Gi
     claims:
-      - name: gateway-data
+      - name: backend-data
         size: 1Gi
         storageClass: gp2
 read:
@@ -133,7 +133,7 @@ write:
     storageClass: gp2
     size: 1Gi
     claims:
-      - name: gateway-data
+      - name: write-data
         size: 1Gi
         storageClass: gp2
 

--- a/values/loki_values.yaml
+++ b/values/loki_values.yaml
@@ -54,7 +54,7 @@ serviceAccount:
     'eks.amazonaws.com/role-arn': 'arn:aws:iam::<Account ID>:role/LokiServiceAccountRole' # The service role you created
 
 deploymentMode: SimpleScalable
-# Holdovers from 
+# Holdovers from microservices mode
 # ingester:
 #   replicas: 3
 #   zoneAwareReplication:

--- a/values/loki_values.yaml
+++ b/values/loki_values.yaml
@@ -1,0 +1,141 @@
+loki:
+  schemaConfig:
+    configs:
+      - from: '2024-04-01'
+        store: tsdb
+        object_store: s3
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storage_config:
+    aws:
+      region: us-east-1 # for example, eu-west-2
+      bucketnames: loki-aws-dev-chunks-unilogs # Your actual S3 bucket name, for example, loki-aws-dev-chunks
+      s3forcepathstyle: false
+  ingester:
+    chunk_encoding: snappy
+  pattern_ingester:
+    enabled: true
+  limits_config:
+    allow_structured_metadata: true
+    volume_enabled: true
+    retention_period: 672h # 28 days retention
+  compactor:
+    retention_enabled: true
+    delete_request_store: s3
+  ruler:
+    enable_api: true
+    storage:
+      type: s3
+      s3:
+        region: us-east-1 # for example, eu-west-2
+        bucketnames: loki-aws-dev-ruler-unilogs # Your actual S3 bucket name, for example, loki-aws-dev-ruler
+        s3forcepathstyle: false
+      alertmanager_url: http://prom:9093 # The URL of the Alertmanager to send alerts (Prometheus, Mimir, etc.)
+
+  querier:
+    max_concurrent: 4
+
+  storage:
+    type: s3
+    bucketNames:
+      chunks: 'loki-aws-dev-chunks-unilogs' # Your actual S3 bucket name (loki-aws-dev-chunks)
+      ruler: 'loki-aws-dev-ruler-unilogs' # Your actual S3 bucket name (loki-aws-dev-ruler)
+      # admin: "<Insert s3 bucket name>" # Your actual S3 bucket name (loki-aws-dev-admin) - GEL customers only
+    s3:
+      region: us-east-1 # eu-west-2
+      #insecure: false
+    # s3forcepathstyle: false
+
+serviceAccount:
+  create: true
+  annotations:
+    'eks.amazonaws.com/role-arn': 'arn:aws:iam::<Account ID>:role/LokiServiceAccountRole' # The service role you created
+
+deploymentMode: SimpleScalable
+
+# ingester:
+#   replicas: 3
+#   zoneAwareReplication:
+#     enabled: false
+
+# querier:
+#   replicas: 3
+#   maxUnavailable: 2
+
+# queryFrontend:
+#   replicas: 2
+#   maxUnavailable: 1
+
+# queryScheduler:
+#   replicas: 2
+
+# distributor:
+#   replicas: 3
+#   maxUnavailable: 2
+# compactor:
+#   replicas: 1
+
+# indexGateway:
+#   replicas: 2
+#   maxUnavailable: 1
+
+# ruler:
+#   replicas: 1
+#   maxUnavailable: 1
+
+# This exposes the Loki gateway so it can be written to and queried externaly
+gateway:
+  service:
+    type: LoadBalancer
+  basicAuth:
+    enabled: true
+    existingSecret: loki-basic-auth
+
+# Since we are using basic auth, we need to pass the username and password to the canary
+lokiCanary:
+  extraArgs:
+    - -pass=$(LOKI_PASS)
+    - -user=$(LOKI_USER)
+  extraEnv:
+    - name: LOKI_PASS
+      valueFrom:
+        secretKeyRef:
+          name: canary-basic-auth
+          key: password
+    - name: LOKI_USER
+      valueFrom:
+        secretKeyRef:
+          name: canary-basic-auth
+          key: username
+
+# Enable minio for storage
+minio:
+  enabled: false
+
+backend:
+  replicas: 3
+  persistence:
+    enabled: true
+    storageClass: gp2
+    size: 1Gi
+    claims:
+      - name: gateway-data
+        size: 1Gi
+        storageClass: gp2
+read:
+  replicas: 3
+write:
+  replicas: 3
+  persistence:
+    enabled: true
+    storageClass: gp2
+    size: 1Gi
+    claims:
+      - name: gateway-data
+        size: 1Gi
+        storageClass: gp2
+
+singleBinary:
+  replicas: 0


### PR DESCRIPTION
What this fixed:
Loki can now run on simple scalable mode without the PVC errors we were getting. Grafana should no longer scream at us for not having a persistent volume (as a bonus, Grafana now detects Loki as a datasource without any configuration from the end-user). 

How to test:
After setting up your cluster and connecting it to `kubectl`:
* `htpasswd -c .htpasswd admin`
*  type `secret` to be the password
*  `kubectl create secret generic loki-basic-auth --from-file=.htpasswd`
* `kubectl create secret generic canary-basic-auth \
  --from-literal=username=admin \
  --from-literal=password=secret \
  -n loki`
* change `loki-aws-dev-chunks-unilogs`/`loki-aws-dev-ruler-unilogs` in `loki_values.yaml` to whatever your chunk/ruler s3 buckets are named
* create a `LokiServiceAccountRole` that has permissions to delete/put/delete/list from your s3 buckets
* fill `<ACCOUNT ID>` with your account id in `loki_values.yaml` (line 54)
* `helm install --values loki_values.yaml loki grafana/loki`
* `helm install --values grafana_values.yaml grafana grafana/grafana`
* `kubectl port-forward svc/loki-gateway 3100:80`
*  `curl -H "Content-Type: application/json" -XPOST -s "http://127.0.0.1:3100/loki/api/v1/push"  --data-raw "{\"streams\": [{\"stream\": {\"job\": \"test\"}, \"values\": [[\"$(date +%s)000000000\", \"fizzbuzz\"]]}]}" -H X-Scope-OrgId:default -u admin:secret`
*  Note down the password returned by: `kubectl get secret grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`
*  Get grafana running locally by `export POD_NAME=$(kubectl get pods --namespace loki -l "app.kubernetes.io/name=grafana,app.kubernetes.io/instance=grafana" -o jsonpath="{.items[0].metadata.name}")
     kubectl --namespace loki port-forward $POD_NAME 3000`
* login to grafana with `admin` and the password recieved from the cli
* go to `dashboards` click `create a visualization`
* turn on `table view`
* set `Label filters` `job` to `test` and query
* see the test log on the table