### PR TITLE
61 loki not connecting to grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # unilogs
+
 1. Start Kafka, Vector Consumer, Loki, Grafana UI with docker compose up -d.
 2. Kafka Monitor app can be used to monitor that Kafka server is online and what data is entering into the message queue.
 3. After verifying Kafka server is running, run each logger app and then run docker compose up -d for the vector shippers for each app.
+
+# Dev purposes:
+
+- `aws eks update-kubeconfig --region region-code --name my-cluster`
+- `eksctl create addon --name aws-ebs-csi-driver --cluster unilogs-cluster --region region-code`

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -296,18 +296,7 @@ export class UnilogsCdkStack extends cdk.Stack {
         deploymentMode: 'SimpleScalable',
         backend: {
           replicas: 1, // Reduced from 2
-          persistence: { 
-            enabled: true, 
-            storageClass: 'gp2',
-            size: '1Gi', 
-            claims: [
-              {
-                name: "backend-data",
-                size: "1Gi",
-                storageClass: "gp2"
-              }
-            ]
-          },
+          persistence: { enabled: true, storageClass: 'gp2', size: '1Gi' },
         },
         read: {
           replicas: 1, // Reduced from 2
@@ -315,19 +304,8 @@ export class UnilogsCdkStack extends cdk.Stack {
           // persistence: { enabled: true, storageClass: 'gp2', size: '1Gi' },
         },
         write: {
-          replicas: 1, // Reduced from 2
-          persistence: { 
-            enabled: true, 
-            storageClass: 'gp2',
-            size: '1Gi', 
-            claims: [
-              {
-                name: "backend-data",
-                size: "1Gi",
-                storageClass: "gp2"
-              }
-            ]
-          },
+          replicas: 1, // Reduced from 3
+          persistence: { enabled: true, storageClass: 'gp2', size: '1Gi' },
         },
         minio: {
           enabled: false,
@@ -399,7 +377,7 @@ export class UnilogsCdkStack extends cdk.Stack {
             apiVersion: 1,
             datasources: [
               {
-                name: 'loki',
+                name: 'Loki',
                 type: 'loki',
                 url: 'http://loki-gateway.loki.svc.cluster.local',
                 access: 'proxy',

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -296,15 +296,38 @@ export class UnilogsCdkStack extends cdk.Stack {
         deploymentMode: 'SimpleScalable',
         backend: {
           replicas: 1, // Reduced from 2
-          persistence: { enabled: true, storageClassName: 'gp2', size: '10Gi' },
+          persistence: { 
+            enabled: true, 
+            storageClass: 'gp2',
+            size: '1Gi', 
+            claims: [
+              {
+                name: "backend-data",
+                size: "1Gi",
+                storageClass: "gp2"
+              }
+            ]
+          },
         },
         read: {
           replicas: 1, // Reduced from 2
-          persistence: { enabled: true, storageClassName: 'gp2', size: '10Gi' },
+          // read shouldn't need persistence
+          // persistence: { enabled: true, storageClass: 'gp2', size: '1Gi' },
         },
         write: {
-          replicas: 1, // Reduced from 3
-          persistence: { enabled: true, storageClassName: 'gp2', size: '10Gi' },
+          replicas: 1, // Reduced from 2
+          persistence: { 
+            enabled: true, 
+            storageClass: 'gp2',
+            size: '1Gi', 
+            claims: [
+              {
+                name: "backend-data",
+                size: "1Gi",
+                storageClass: "gp2"
+              }
+            ]
+          },
         },
         minio: {
           enabled: false,
@@ -376,14 +399,18 @@ export class UnilogsCdkStack extends cdk.Stack {
             apiVersion: 1,
             datasources: [
               {
-                name: 'Loki',
+                name: 'loki',
                 type: 'loki',
                 url: 'http://loki-gateway.loki.svc.cluster.local',
                 access: 'proxy',
                 isDefault: true,
                 jsonData: {
                   maxLines: 1000,
+                  httpHeaderName1: 'X-Scope-OrgId'
                 },
+                secureJsonData: {
+                  httpHeaderValue1: 'default'
+                }
               },
             ],
           },

--- a/unilogs-cdk/package-lock.json
+++ b/unilogs-cdk/package-lock.json
@@ -3508,6 +3508,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3540,6 +3541,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3549,6 +3551,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3591,6 +3594,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3607,6 +3611,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -4134,12 +4139,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4360,6 +4367,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4372,12 +4380,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -4572,6 +4582,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -4672,6 +4683,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -4685,6 +4697,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4771,6 +4784,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -4893,6 +4907,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -5018,6 +5033,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5805,6 +5821,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5824,6 +5841,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5883,6 +5901,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -5988,6 +6007,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6307,6 +6327,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6370,6 +6391,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6426,6 +6448,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6498,6 +6521,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6512,6 +6536,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6583,6 +6608,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
       "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -6808,6 +6834,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"


### PR DESCRIPTION
# What changed:
* Loki gateway is now no longer set-up manually by creating a `lokiGatewayService`
* Loki gateway now uses basic auth with a username of `admin` and password of `secret`
* **Major**: Grafana now automatically connects to loki.
* Loki gateway now actually works and you can check if its working by hitting up its public ip. (you'll get a file with just `OK`)

# How to test
* `cdk deploy`
* wait 200 years for deployment
*  `aws eks update-kubeconfig --region <REGION CODE HERE> --name unilogs-cluster`
*  `eksctl create addon --name aws-ebs-csi-driver --cluster unilogs-cluster --region <REGION CODE HERE>`
*  `kubectl get all -n grafana` and copy the external ip
*  long into grafana with credentials of: `admin` `admin`
* go to `datasources`
* find the one automatically created, scroll down and click `test`
# Misc
* I'm not sure if the change from `storageClassName` to `storageClass` had any effect on the `persistence` property, but it doesn't seem to break anything.
* I'm not exactly sure why all those `"dev"`s were added to `package.json`