### PR TITLE
79 test removing mskkafka completely and shipping straight to loki

### DIFF
--- a/configuration_generator/.gitignore
+++ b/configuration_generator/.gitignore
@@ -1,1 +1,2 @@
 vector-shipper.yaml
+build/

--- a/configuration_generator/lib/VectorConfiguration.ts
+++ b/configuration_generator/lib/VectorConfiguration.ts
@@ -63,7 +63,7 @@ export class VectorConfiguration {
 
     const mySinks: Record<
       string,
-      Record<string, string | string[] | Record<string, string | string[] | boolean>>
+      Record<string, string | string[] | Record<string, string | string[] | boolean | undefined>>
     > = {};
     for (const sink of this.sinks) {
       mySinks[sink.sinkName] = sink.getObjectBody();

--- a/configuration_generator/main.ts
+++ b/configuration_generator/main.ts
@@ -299,9 +299,9 @@ async function createKafkaSink(): Promise<KafkaSink> {
     type: SinkType.Kafka,
     inputs: [],
     bootstrap_servers,
-    sasl: username
-      ? { enabled: true, mechanism: 'SCRAM-SHA-512', username, password }
-      : undefined,
+    // sasl: username
+    //   ? { enabled: true, mechanism: 'SCRAM-SHA-512', username, password }
+    //   : undefined,
   });
 }
 

--- a/configuration_generator/main.ts
+++ b/configuration_generator/main.ts
@@ -150,25 +150,25 @@ async function createTransform(
     return new ClfTransform({
       serviceName,
       inputs: [inputSource],
-      transformName
+      transformName,
     });
   } else if (transformType === 'linux_authorization') {
     return new LinuxAuthorizationTransform({
       serviceName,
       inputs: [inputSource],
-      transformName
+      transformName,
     });
   } else if (transformType === 'logfmt') {
     return new LogfmtTransform({
       serviceName,
       inputs: [inputSource],
-      transformName
+      transformName,
     });
   } else if (transformType === 'syslog') {
     return new SyslogTransform({
       serviceName,
       inputs: [inputSource],
-      transformName
+      transformName,
     });
   } else {
     return new PlainTextTransform({
@@ -299,7 +299,9 @@ async function createKafkaSink(): Promise<KafkaSink> {
     type: SinkType.Kafka,
     inputs: [],
     bootstrap_servers,
-    sasl: { enabled: true, mechanism: 'SCRAM-SHA-512', username, password },
+    sasl: username
+      ? { enabled: true, mechanism: 'SCRAM-SHA-512', username, password }
+      : undefined,
   });
 }
 
@@ -370,7 +372,7 @@ async function addSinkBuildAndRun(vectorConfiguration: VectorConfiguration) {
 async function main() {
   const vectorConfiguration = new VectorConfiguration();
   let notDone = true;
-  if (await getContainerIdByName(CONTAINER_NAME) !== '') {
+  if ((await getContainerIdByName(CONTAINER_NAME)) !== '') {
     console.log(`A container named ${CONTAINER_NAME} is already running.`);
     console.log('Please delete it and then try again.');
     notDone = false;

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -1,7 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import { CfnJson } from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as msk from 'aws-cdk-lib/aws-msk';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import * as eks from 'aws-cdk-lib/aws-eks';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { KubectlV32Layer as KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v32';
@@ -36,13 +38,92 @@ export class UnilogsCdkStack extends cdk.Stack {
       ],
     });
 
+    // ==================== MSK KAFKA CLUSTER ====================
+    const mskConfig = new msk.CfnConfiguration(this, 'MskConfig', {
+      name: 'unilogs-config',
+      kafkaVersionsList: ['3.6.0'],
+      serverProperties: `
+        auto.create.topics.enable=true
+        num.partitions=3
+        default.replication.factor=2
+      `,
+    });
+
+    const mskSecurityGroup = new ec2.SecurityGroup(this, 'MskSecurityGroup', {
+      vpc,
+      description: 'Security group for MSK cluster',
+      allowAllOutbound: true,
+    });
+    mskSecurityGroup.addIngressRule(
+      ec2.Peer.ipv4(vpc.vpcCidrBlock),
+      ec2.Port.tcpRange(9092, 9098),
+      'Allow from EKS pods'
+    );
+
+    const mskCluster = new msk.CfnCluster(this, 'UniLogsKafka', {
+      clusterName: 'unilogs-kafka',
+      kafkaVersion: '3.6.0',
+      numberOfBrokerNodes: 2,
+      brokerNodeGroupInfo: {
+        instanceType: 'kafka.t3.small', // Cost optimized (originally m5.large), reduced for dev only
+        clientSubnets: vpc.selectSubnets({
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+        }).subnetIds,
+        securityGroups: [mskSecurityGroup.securityGroupId],
+        storageInfo: {
+          ebsStorageInfo: {
+            volumeSize: 20, // Reduced from 100GB for dev
+          },
+        },
+      },
+      clientAuthentication: {
+        sasl: {
+          iam: {
+            enabled: true,
+          },
+        },
+      },
+      encryptionInfo: {
+        encryptionInTransit: {
+          clientBroker: 'TLS',
+          inCluster: true,
+        },
+      },
+      configurationInfo: {
+        arn: mskConfig.attrArn,
+        revision: 1,
+      },
+    });
+
+    // Custom resource to get MSK brokers
+    const mskBrokersRole = new iam.Role(this, 'MskBrokersRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    mskBrokersRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['kafka:GetBootstrapBrokers', 'kafka:DescribeCluster'],
+        resources: [mskCluster.attrArn],
+      })
+    );
+
+    const mskBrokers = new cr.AwsCustomResource(this, 'MskBootstrapBrokers', {
+      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
+      }),
+      onCreate: {
+        service: 'Kafka',
+        action: 'getBootstrapBrokers',
+        parameters: {
+          ClusterArn: mskCluster.attrArn,
+        },
+        physicalResourceId: cr.PhysicalResourceId.of('MskBootstrapBrokers'),
+      },
+      role: mskBrokersRole,
+    });
+
     // ==================== EKS CLUSTER ====================
 
-    const deployingUser = iam.User.fromUserName(
-      this,
-      'DeployingUser',
-      process.env.AWS_USER_NAME!
-    );
+    const deployingUser = iam.User.fromUserName(this, 'DeployingUser', process.env.AWS_USER_NAME!);
 
     // enable all logging types for dev, comment out others beyond AUDIT for production (matching AWS sample code)
     const clusterLogging = [
@@ -78,22 +159,25 @@ export class UnilogsCdkStack extends cdk.Stack {
         app: 'unilogs',
         'workload-type': 'application',
       },
-      nodeRole: new iam.Role(this, 'EKSClusterNodeGroupRole', {
-        roleName: 'EKSClusterNodeGroupRole',
-        assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+      nodeRole: new iam.Role(this, "EKSClusterNodeGroupRole", {
+        roleName: "EKSClusterNodeGroupRole",
+        assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
         managedPolicies: [
-          'AmazonEKSWorkerNodePolicy',
-          'AmazonEC2ContainerRegistryReadOnly',
-          'AmazonEKS_CNI_Policy',
+          "AmazonEKSWorkerNodePolicy",
+          "AmazonEC2ContainerRegistryReadOnly",
+          "AmazonEKS_CNI_Policy",
         ].map((policy) => iam.ManagedPolicy.fromAwsManagedPolicyName(policy)),
       }),
     });
 
     // Explicitly map the IAM user
-    cluster.awsAuth.addUserMapping(deployingUser, {
-      groups: ['system:masters'],
-      username: 'deployingUserAdmin',
-    });
+    cluster.awsAuth.addUserMapping(
+      deployingUser,
+      {
+        groups: ['system:masters'],
+        username: 'deployingUserAdmin',
+      }
+    );
 
     // ---------------- EKS Add-ons ----------------------
 
@@ -104,18 +188,13 @@ export class UnilogsCdkStack extends cdk.Stack {
     });
 
     // driver needed to provision PVCs - patching role into its service account
-    const ebsCsiServiceAccount = cluster.addServiceAccount(
-      'EbsCsiServiceAccount',
-      {
-        name: 'ebs-csi-controller-sa',
-        namespace: 'kube-system', // default for this add-on, other things may expect it
-      }
-    );
+    const ebsCsiServiceAccount = cluster.addServiceAccount('EbsCsiServiceAccount', {
+      name: 'ebs-csi-controller-sa',
+      namespace: 'kube-system', // default for this add-on, other things may expect it
+    });
 
     ebsCsiServiceAccount.role.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName(
-        'service-role/AmazonEBSCSIDriverPolicy'
-      )
+      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEBSCSIDriverPolicy')
     );
 
     cluster.addHelmChart('EbsCsiDriverHelm', {
@@ -128,7 +207,7 @@ export class UnilogsCdkStack extends cdk.Stack {
             create: false,
             name: ebsCsiServiceAccount.serviceAccountName,
           },
-        },
+        }
       },
     });
 
@@ -251,19 +330,13 @@ export class UnilogsCdkStack extends cdk.Stack {
         },
         gateway: {
           service: {
-            type: 'LoadBalancer',
-            port: '3100',
-            annotations: {
-              'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
-              'service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags':
-                'name=unilogs-loki-lb',
-            },
+            type: 'LoadBalancer'
           },
           basicAuth: {
             enabled: true,
             username: 'admin',
-            password: 'secret',
-          },
+            password: 'secret'
+          }
         },
         serviceAccount: {
           create: true,
@@ -274,6 +347,32 @@ export class UnilogsCdkStack extends cdk.Stack {
         },
       },
     });
+
+    // Custom Gateway Service with NLB
+    // const lokiGatewayService = cluster.addManifest('LokiGatewayService', {
+    //   apiVersion: 'v1',
+    //   kind: 'Service',
+    //   metadata: {
+    //     name: 'loki-gateway',
+    //     namespace: 'loki',
+    //     labels: { app: 'loki', component: 'gateway' },
+    //     annotations: {
+    //       'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
+    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold':
+    //         '2',
+    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold':
+    //         '2',
+    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval':
+    //         '10',
+    //     },
+    //   },
+    //   spec: {
+    //     type: 'LoadBalancer',
+    //     ports: [{ port: 80, targetPort: 80, protocol: 'TCP' }],
+    //     selector: { app: 'loki', component: 'gateway' },
+    //   },
+    // });
+    // lokiGatewayService.node.addDependency(lokiChart);
 
     // ==================== GRAFANA UI DEPLOYMENT ====================
     const grafanaCondition = createConditionJson(
@@ -311,12 +410,12 @@ export class UnilogsCdkStack extends cdk.Stack {
                 jsonData: {
                   maxLines: 1000,
                   httpHeaderName1: 'X-Scope-OrgId',
-                  httpHeaderName2: 'Authorization',
+                  httpHeaderName2: 'Authorization'
                 },
                 secureJsonData: {
                   httpHeaderValue1: 'default',
-                  httpHeaderValue2: 'Basic YWRtaW46c2VjcmV0', // `echo -n "admin:secret" | base64`
-                },
+                  httpHeaderValue2: 'Basic YWRtaW46c2VjcmV0' // `echo -n "admin:secret" | base64`
+                }
               },
             ],
           },
@@ -325,8 +424,6 @@ export class UnilogsCdkStack extends cdk.Stack {
           type: 'LoadBalancer',
           annotations: {
             'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
-            'service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags':
-              'name=unilogs-grafana-lb',
           },
         },
         serviceAccount: {
@@ -343,12 +440,143 @@ export class UnilogsCdkStack extends cdk.Stack {
     // not sure if I can add dependancies like this, but it's worth a try as it seems how vector gets a dependancy on grafana
     grafanaChart.node.addDependency(lokiChart);
 
+    // ==================== VECTOR CONSUMER DEPLOYMENT ====================
+    const vectorCondition = createConditionJson(
+      'VectorCondition',
+      'vector:vector-service-account'
+    );
+    const vectorRole = new iam.Role(this, 'VectorRole', {
+      assumedBy: new iam.WebIdentityPrincipal(
+        cluster.openIdConnectProvider.openIdConnectProviderArn,
+        {
+          StringEquals: vectorCondition,
+        }
+      ),
+    });
+
+    vectorRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          'kafka-cluster:Connect',
+          'kafka-cluster:DescribeGroup',
+          'kafka-cluster:DescribeCluster',
+          'kafka-cluster:ReadData',
+          'kafka-cluster:Read',
+          'kafka-cluster:Describe',
+          'kafka:DescribeCluster',
+          'kafka:GetBootstrapBrokers',
+        ],
+        resources: [mskCluster.attrArn],
+      })
+    );
+
+    const vectorChart = cluster.addHelmChart('VectorConsumer', {
+      chart: 'vector',
+      repository: 'https://helm.vector.dev',
+      namespace: 'vector',
+      createNamespace: true,
+      values: {
+        role: 'Agent',
+        serviceAccount: {
+          create: true,
+          name: 'vector-service-account',
+          annotations: {
+            'eks.amazonaws.com/role-arn': vectorRole.roleArn,
+          },
+        },
+        customConfig: {
+          sources: {
+            kafka: {
+              type: 'kafka',
+              bootstrap_servers: mskBrokers.getResponseField(
+                'BootstrapBrokerStringSaslIam'
+              ),
+              group_id: 'vector-consumer',
+              topics: ['app_logs_topic'],
+              sasl: {
+                mechanism: 'AWS_MSK_IAM',
+                oauthbearer_token_provider: 'aws',
+                region: this.region,
+              },
+              auto_offset_reset: 'earliest',
+            },
+          },
+          sinks: {
+            loki: {
+              type: 'loki',
+              inputs: ['kafka'],
+              endpoint: 'http://loki-gateway.loki.svc.cluster.local',
+              labels: {
+                unilogs: 'test_label',
+                agent: 'vector',
+              },
+              encoding: {
+                codec: 'json',
+              },
+            },
+          },
+        },
+        service: {
+          enabled: true,
+          type: 'ClusterIP',
+          ports: [
+            {
+              name: 'vector',
+              port: 8686,
+              targetPort: 8686,
+              protocol: 'TCP',
+            },
+          ],
+        },
+      },
+    });
+
+    const vectorNamespace = cluster.addManifest('VectorNamespace', {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: 'vector' },
+    });
+
+    vectorChart.node.addDependency(vectorNamespace);
+
+    // MSK Cluster Policy
+    new msk.CfnClusterPolicy(this, 'MskClusterPolicy', {
+      clusterArn: mskCluster.attrArn,
+      policy: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { AWS: vectorRole.roleArn },
+            Action: 'kafka-cluster:*',
+            Resource: mskCluster.attrArn,
+          },
+        ],
+      },
+    });
+
     // ==================== DEPENDENCIES ====================
-    lokiChart.node.addDependency(lokiChunkBucket, lokiRulerBucket);
+    lokiChart.node.addDependency(
+      lokiChunkBucket,
+      lokiRulerBucket,
+      mskCluster
+    );
+
+    cluster.node.addDependency(mskCluster);
+    cluster.node.addDependency(mskSecurityGroup);
+    vectorChart.node.addDependency(
+      mskCluster,
+      // lokiGatewayService,
+      grafanaChart,
+      mskBrokers
+    );
 
     // ==================== OUTPUTS ====================
     new cdk.CfnOutput(this, 'ClusterName', { value: cluster.clusterName });
     new cdk.CfnOutput(this, 'VpcId', { value: vpc.vpcId });
+    new cdk.CfnOutput(this, 'KafkaBootstrapServers', {
+      value: mskBrokers.getResponseField('BootstrapBrokerStringSaslIam'),
+    });
     new cdk.CfnOutput(this, 'LokiGatewayEndpoint', {
       value: `http://loki-gateway.loki.svc.cluster.local`,
     });
@@ -367,5 +595,5 @@ export class UnilogsCdkStack extends cdk.Stack {
 
 // explicitly instantiate app, stack, and synth() to ensure updated template
 const app = new cdk.App();
-new UnilogsCdkStack(app, 'UnilogsEksStack');
+new UnilogsCdkStack(app, 'EksStack');
 app.synth();

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -1,9 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { CfnJson } from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as msk from 'aws-cdk-lib/aws-msk';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import * as cr from 'aws-cdk-lib/custom-resources';
 import * as eks from 'aws-cdk-lib/aws-eks';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { KubectlV32Layer as KubectlLayer } from '@aws-cdk/lambda-layer-kubectl-v32';
@@ -38,92 +36,13 @@ export class UnilogsCdkStack extends cdk.Stack {
       ],
     });
 
-    // ==================== MSK KAFKA CLUSTER ====================
-    const mskConfig = new msk.CfnConfiguration(this, 'MskConfig', {
-      name: 'unilogs-config',
-      kafkaVersionsList: ['3.6.0'],
-      serverProperties: `
-        auto.create.topics.enable=true
-        num.partitions=3
-        default.replication.factor=2
-      `,
-    });
-
-    const mskSecurityGroup = new ec2.SecurityGroup(this, 'MskSecurityGroup', {
-      vpc,
-      description: 'Security group for MSK cluster',
-      allowAllOutbound: true,
-    });
-    mskSecurityGroup.addIngressRule(
-      ec2.Peer.ipv4(vpc.vpcCidrBlock),
-      ec2.Port.tcpRange(9092, 9098),
-      'Allow from EKS pods'
-    );
-
-    const mskCluster = new msk.CfnCluster(this, 'UniLogsKafka', {
-      clusterName: 'unilogs-kafka',
-      kafkaVersion: '3.6.0',
-      numberOfBrokerNodes: 2,
-      brokerNodeGroupInfo: {
-        instanceType: 'kafka.t3.small', // Cost optimized (originally m5.large), reduced for dev only
-        clientSubnets: vpc.selectSubnets({
-          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
-        }).subnetIds,
-        securityGroups: [mskSecurityGroup.securityGroupId],
-        storageInfo: {
-          ebsStorageInfo: {
-            volumeSize: 20, // Reduced from 100GB for dev
-          },
-        },
-      },
-      clientAuthentication: {
-        sasl: {
-          iam: {
-            enabled: true,
-          },
-        },
-      },
-      encryptionInfo: {
-        encryptionInTransit: {
-          clientBroker: 'TLS',
-          inCluster: true,
-        },
-      },
-      configurationInfo: {
-        arn: mskConfig.attrArn,
-        revision: 1,
-      },
-    });
-
-    // Custom resource to get MSK brokers
-    const mskBrokersRole = new iam.Role(this, 'MskBrokersRole', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-    });
-    mskBrokersRole.addToPolicy(
-      new iam.PolicyStatement({
-        actions: ['kafka:GetBootstrapBrokers', 'kafka:DescribeCluster'],
-        resources: [mskCluster.attrArn],
-      })
-    );
-
-    const mskBrokers = new cr.AwsCustomResource(this, 'MskBootstrapBrokers', {
-      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
-        resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
-      }),
-      onCreate: {
-        service: 'Kafka',
-        action: 'getBootstrapBrokers',
-        parameters: {
-          ClusterArn: mskCluster.attrArn,
-        },
-        physicalResourceId: cr.PhysicalResourceId.of('MskBootstrapBrokers'),
-      },
-      role: mskBrokersRole,
-    });
-
     // ==================== EKS CLUSTER ====================
 
-    const deployingUser = iam.User.fromUserName(this, 'DeployingUser', process.env.AWS_USER_NAME!);
+    const deployingUser = iam.User.fromUserName(
+      this,
+      'DeployingUser',
+      process.env.AWS_USER_NAME!
+    );
 
     // enable all logging types for dev, comment out others beyond AUDIT for production (matching AWS sample code)
     const clusterLogging = [
@@ -159,25 +78,22 @@ export class UnilogsCdkStack extends cdk.Stack {
         app: 'unilogs',
         'workload-type': 'application',
       },
-      nodeRole: new iam.Role(this, "EKSClusterNodeGroupRole", {
-        roleName: "EKSClusterNodeGroupRole",
-        assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+      nodeRole: new iam.Role(this, 'EKSClusterNodeGroupRole', {
+        roleName: 'EKSClusterNodeGroupRole',
+        assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
         managedPolicies: [
-          "AmazonEKSWorkerNodePolicy",
-          "AmazonEC2ContainerRegistryReadOnly",
-          "AmazonEKS_CNI_Policy",
+          'AmazonEKSWorkerNodePolicy',
+          'AmazonEC2ContainerRegistryReadOnly',
+          'AmazonEKS_CNI_Policy',
         ].map((policy) => iam.ManagedPolicy.fromAwsManagedPolicyName(policy)),
       }),
     });
 
     // Explicitly map the IAM user
-    cluster.awsAuth.addUserMapping(
-      deployingUser,
-      {
-        groups: ['system:masters'],
-        username: 'deployingUserAdmin',
-      }
-    );
+    cluster.awsAuth.addUserMapping(deployingUser, {
+      groups: ['system:masters'],
+      username: 'deployingUserAdmin',
+    });
 
     // ---------------- EKS Add-ons ----------------------
 
@@ -188,13 +104,18 @@ export class UnilogsCdkStack extends cdk.Stack {
     });
 
     // driver needed to provision PVCs - patching role into its service account
-    const ebsCsiServiceAccount = cluster.addServiceAccount('EbsCsiServiceAccount', {
-      name: 'ebs-csi-controller-sa',
-      namespace: 'kube-system', // default for this add-on, other things may expect it
-    });
+    const ebsCsiServiceAccount = cluster.addServiceAccount(
+      'EbsCsiServiceAccount',
+      {
+        name: 'ebs-csi-controller-sa',
+        namespace: 'kube-system', // default for this add-on, other things may expect it
+      }
+    );
 
     ebsCsiServiceAccount.role.addManagedPolicy(
-      iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonEBSCSIDriverPolicy')
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        'service-role/AmazonEBSCSIDriverPolicy'
+      )
     );
 
     cluster.addHelmChart('EbsCsiDriverHelm', {
@@ -207,7 +128,7 @@ export class UnilogsCdkStack extends cdk.Stack {
             create: false,
             name: ebsCsiServiceAccount.serviceAccountName,
           },
-        }
+        },
       },
     });
 
@@ -330,13 +251,19 @@ export class UnilogsCdkStack extends cdk.Stack {
         },
         gateway: {
           service: {
-            type: 'LoadBalancer'
+            type: 'LoadBalancer',
+            port: '3100',
+            annotations: {
+              'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
+              'service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags':
+                'name=unilogs-loki-lb',
+            },
           },
           basicAuth: {
             enabled: true,
             username: 'admin',
-            password: 'secret'
-          }
+            password: 'secret',
+          },
         },
         serviceAccount: {
           create: true,
@@ -347,32 +274,6 @@ export class UnilogsCdkStack extends cdk.Stack {
         },
       },
     });
-
-    // Custom Gateway Service with NLB
-    // const lokiGatewayService = cluster.addManifest('LokiGatewayService', {
-    //   apiVersion: 'v1',
-    //   kind: 'Service',
-    //   metadata: {
-    //     name: 'loki-gateway',
-    //     namespace: 'loki',
-    //     labels: { app: 'loki', component: 'gateway' },
-    //     annotations: {
-    //       'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
-    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold':
-    //         '2',
-    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold':
-    //         '2',
-    //       'service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval':
-    //         '10',
-    //     },
-    //   },
-    //   spec: {
-    //     type: 'LoadBalancer',
-    //     ports: [{ port: 80, targetPort: 80, protocol: 'TCP' }],
-    //     selector: { app: 'loki', component: 'gateway' },
-    //   },
-    // });
-    // lokiGatewayService.node.addDependency(lokiChart);
 
     // ==================== GRAFANA UI DEPLOYMENT ====================
     const grafanaCondition = createConditionJson(
@@ -410,12 +311,12 @@ export class UnilogsCdkStack extends cdk.Stack {
                 jsonData: {
                   maxLines: 1000,
                   httpHeaderName1: 'X-Scope-OrgId',
-                  httpHeaderName2: 'Authorization'
+                  httpHeaderName2: 'Authorization',
                 },
                 secureJsonData: {
                   httpHeaderValue1: 'default',
-                  httpHeaderValue2: 'Basic YWRtaW46c2VjcmV0' // `echo -n "admin:secret" | base64`
-                }
+                  httpHeaderValue2: 'Basic YWRtaW46c2VjcmV0', // `echo -n "admin:secret" | base64`
+                },
               },
             ],
           },
@@ -424,6 +325,8 @@ export class UnilogsCdkStack extends cdk.Stack {
           type: 'LoadBalancer',
           annotations: {
             'service.beta.kubernetes.io/aws-load-balancer-type': 'nlb',
+            'service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags':
+              'name=unilogs-grafana-lb',
           },
         },
         serviceAccount: {
@@ -440,143 +343,12 @@ export class UnilogsCdkStack extends cdk.Stack {
     // not sure if I can add dependancies like this, but it's worth a try as it seems how vector gets a dependancy on grafana
     grafanaChart.node.addDependency(lokiChart);
 
-    // ==================== VECTOR CONSUMER DEPLOYMENT ====================
-    const vectorCondition = createConditionJson(
-      'VectorCondition',
-      'vector:vector-service-account'
-    );
-    const vectorRole = new iam.Role(this, 'VectorRole', {
-      assumedBy: new iam.WebIdentityPrincipal(
-        cluster.openIdConnectProvider.openIdConnectProviderArn,
-        {
-          StringEquals: vectorCondition,
-        }
-      ),
-    });
-
-    vectorRole.addToPolicy(
-      new iam.PolicyStatement({
-        actions: [
-          'kafka-cluster:Connect',
-          'kafka-cluster:DescribeGroup',
-          'kafka-cluster:DescribeCluster',
-          'kafka-cluster:ReadData',
-          'kafka-cluster:Read',
-          'kafka-cluster:Describe',
-          'kafka:DescribeCluster',
-          'kafka:GetBootstrapBrokers',
-        ],
-        resources: [mskCluster.attrArn],
-      })
-    );
-
-    const vectorChart = cluster.addHelmChart('VectorConsumer', {
-      chart: 'vector',
-      repository: 'https://helm.vector.dev',
-      namespace: 'vector',
-      createNamespace: true,
-      values: {
-        role: 'Agent',
-        serviceAccount: {
-          create: true,
-          name: 'vector-service-account',
-          annotations: {
-            'eks.amazonaws.com/role-arn': vectorRole.roleArn,
-          },
-        },
-        customConfig: {
-          sources: {
-            kafka: {
-              type: 'kafka',
-              bootstrap_servers: mskBrokers.getResponseField(
-                'BootstrapBrokerStringSaslIam'
-              ),
-              group_id: 'vector-consumer',
-              topics: ['app_logs_topic'],
-              sasl: {
-                mechanism: 'AWS_MSK_IAM',
-                oauthbearer_token_provider: 'aws',
-                region: this.region,
-              },
-              auto_offset_reset: 'earliest',
-            },
-          },
-          sinks: {
-            loki: {
-              type: 'loki',
-              inputs: ['kafka'],
-              endpoint: 'http://loki-gateway.loki.svc.cluster.local',
-              labels: {
-                unilogs: 'test_label',
-                agent: 'vector',
-              },
-              encoding: {
-                codec: 'json',
-              },
-            },
-          },
-        },
-        service: {
-          enabled: true,
-          type: 'ClusterIP',
-          ports: [
-            {
-              name: 'vector',
-              port: 8686,
-              targetPort: 8686,
-              protocol: 'TCP',
-            },
-          ],
-        },
-      },
-    });
-
-    const vectorNamespace = cluster.addManifest('VectorNamespace', {
-      apiVersion: 'v1',
-      kind: 'Namespace',
-      metadata: { name: 'vector' },
-    });
-
-    vectorChart.node.addDependency(vectorNamespace);
-
-    // MSK Cluster Policy
-    new msk.CfnClusterPolicy(this, 'MskClusterPolicy', {
-      clusterArn: mskCluster.attrArn,
-      policy: {
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: { AWS: vectorRole.roleArn },
-            Action: 'kafka-cluster:*',
-            Resource: mskCluster.attrArn,
-          },
-        ],
-      },
-    });
-
     // ==================== DEPENDENCIES ====================
-    lokiChart.node.addDependency(
-      lokiChunkBucket,
-      lokiRulerBucket,
-      mskCluster
-    );
-
-    cluster.node.addDependency(mskCluster);
-    cluster.node.addDependency(mskSecurityGroup);
-    vectorChart.node.addDependency(
-      mskCluster,
-      // lokiGatewayService,
-      grafanaChart,
-      mskBrokers
-    );
+    lokiChart.node.addDependency(lokiChunkBucket, lokiRulerBucket);
 
     // ==================== OUTPUTS ====================
     new cdk.CfnOutput(this, 'ClusterName', { value: cluster.clusterName });
     new cdk.CfnOutput(this, 'VpcId', { value: vpc.vpcId });
-    new cdk.CfnOutput(this, 'KafkaBootstrapServers', {
-      value: mskBrokers.getResponseField('BootstrapBrokerStringSaslIam'),
-    });
     new cdk.CfnOutput(this, 'LokiGatewayEndpoint', {
       value: `http://loki-gateway.loki.svc.cluster.local`,
     });
@@ -595,5 +367,5 @@ export class UnilogsCdkStack extends cdk.Stack {
 
 // explicitly instantiate app, stack, and synth() to ensure updated template
 const app = new cdk.App();
-new UnilogsCdkStack(app, 'EksStack');
+new UnilogsCdkStack(app, 'UnilogsEksStack');
 app.synth();


### PR DESCRIPTION
Ignore the branch title! This PR does two things:
1. Adds support for a Loki sink basic authentication (which we will not really be using in the long run, but it might have been helpful for testing). Originally the Loki sink could only do 'bearer' token authentication because that's what I was using for testing with Grafana Cloud.
2. More importantly, it makes using SCRAM authentication in the shipper optional.

To test the changes, you can set up a shipper to actually ship logs to our latest Unilogs deployment.