### PR TITLE
Delete unilogs-cdk/destroy.sh

### DIFF
--- a/unilogs-cdk/destroy.sh
+++ b/unilogs-cdk/destroy.sh
@@ -1,7 +1,0 @@
-export AWS_ACCESS_KEY_ID="AKIAVGQL722TYFHO3E7X"
-export AWS_SECRET_ACCESS_KEY="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"
-export AWS_DEFAULT_ACCOUNT="357581182631"
-export AWS_DEFAULT_REGION="us-west-2"
-export AWS_USER_NAME="UnilogsAdmin"
-
-cdk destroy --all --force


### PR DESCRIPTION
removing `destroy.sh` from main because it got committed somehow despite .gitignore