### PR TITLE
Shipper -> Grafana pipeline is now active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dist
 
 .env.keys
 cdk.out/
+eksctl/

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dist
 .env.keys
 cdk.out/
 eksctl/
+vector_data/

--- a/apacheLogger/vector-shipper.yaml
+++ b/apacheLogger/vector-shipper.yaml
@@ -1,10 +1,10 @@
-data_dir: "/Users/davidpark/Desktop/unilogs/vector_data"
+data_dir: '/home/jitte/unilogs/vector_data'
 
 sources:
   app_logs:
     type: file
     include:
-      - /Users/davidpark/Desktop/unilogs/apacheLogger/logs/app.log
+      - /home/jitte/unilogs/apacheLogger/logs/app.log
 
 # transforms:
 #   parse_logs:
@@ -36,7 +36,7 @@ sinks:
     type: kafka
     inputs:
       - app_logs
-    bootstrap_servers: "a24e9507739ac44c4b636e7ee7761fe0-5395abb278e54483.elb.us-west-2.amazonaws.com:9094, a7fff562e669e4190a57b8aa11937f27-a1e52383e5ecf813.elb.us-west-2.amazonaws.com:9094, ac94bd83e76574c07823d4319c39efd9-f6bd955bcebee994.elb.us-west-2.amazonaws.com:9094"
+    bootstrap_servers: 'ae971b6add8cb415b9a34a171460ba63-e2a8d73bb390ca80.elb.eu-north-1.amazonaws.com:9094, a03628e95a6c84befad88eef9d46e510-bdeef45fa2e90902.elb.eu-north-1.amazonaws.com:9094, abb45bd944cd34938b4e893f3fbf1bc5-ecd76e406a55d039.elb.eu-north-1.amazonaws.com:9094'
     topic: app_logs_topic
     encoding:
       codec: json

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -422,7 +422,7 @@ export class UnilogsCdkStack extends cdk.Stack {
         },
         gateway: {
           service: {
-            type: 'LoadBalancer',
+            type: 'ClusterIP',
           },
           basicAuth: {
             enabled: true,

--- a/vector_data/app_logs/checkpoints.json
+++ b/vector_data/app_logs/checkpoints.json
@@ -1,0 +1,1 @@
+{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":155208,"modified":"2025-04-10T21:52:36.577117976Z"}]}

--- a/vector_data/app_logs/checkpoints.json
+++ b/vector_data/app_logs/checkpoints.json
@@ -1,1 +1,1 @@
-{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":156671,"modified":"2025-04-10T21:53:20.777885863Z"}]}
+{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":168324,"modified":"2025-04-10T21:58:11.815886054Z"}]}

--- a/vector_data/app_logs/checkpoints.json
+++ b/vector_data/app_logs/checkpoints.json
@@ -1,1 +1,1 @@
-{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":155208,"modified":"2025-04-10T21:52:36.577117976Z"}]}
+{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":156671,"modified":"2025-04-10T21:53:20.777885863Z"}]}


### PR DESCRIPTION
# What Changed?

* It's done! Major milestone for the Unilogs team as we have our first logs coming into kafka and all the way to grafana from a remote machine.
* Removed `port` specifications from the loki chart.
* Loki gateway no longer exposed externally

# How to test
* `bash deploy.sh` in `unilogs-cdk`
* wait for deployment
* `aws eks update-kubeconfig --region <YOUR REGION CODE> --name unilogs-cluster`
* `kubectl get svc -n kafk`
* copy all the external ips to `bootstrap_servers` under `sinks.kafka` in `apacheLogger/vector-shipper.yaml`
* change `vector-shipper.yaml` `data_dir` and `sources.app_logs.include` to point to the correct paths
* run `npm i` and `npm start` under `apacheLogger` 
* run `vector --config <YOUR PATH>/unilogs/vector_data/vector-shipper.yaml`