### PR TITLE
feat:SASL in between vector and kafka. Removed kafkanamespace

### DIFF
--- a/apacheLogger/vector-shipper.yaml
+++ b/apacheLogger/vector-shipper.yaml
@@ -1,10 +1,10 @@
-data_dir: '/home/jitte/unilogs/vector_data'
+data_dir: "/Users/davidpark/Desktop/unilogs/vector_data"
 
 sources:
   app_logs:
     type: file
     include:
-      - /home/jitte/unilogs/apacheLogger/logs/app.log
+      - /Users/davidpark/Desktop/unilogs/apacheLogger/logs/app.log
 
 # transforms:
 #   parse_logs:
@@ -36,10 +36,15 @@ sinks:
     type: kafka
     inputs:
       - app_logs
-    bootstrap_servers: 'ae971b6add8cb415b9a34a171460ba63-e2a8d73bb390ca80.elb.eu-north-1.amazonaws.com:9094, a03628e95a6c84befad88eef9d46e510-bdeef45fa2e90902.elb.eu-north-1.amazonaws.com:9094, abb45bd944cd34938b4e893f3fbf1bc5-ecd76e406a55d039.elb.eu-north-1.amazonaws.com:9094'
+    bootstrap_servers: "a8d7a712dbdb04bfc8a9ee788c1bf473-1543872393.us-west-1.elb.amazonaws.com:9094, af82c2fd49641402dabb29f3f0940d2b-1252711838.us-west-1.elb.amazonaws.com:9094, a7486a3a27fa042bcb780ec356e97d1e-1952032441.us-west-1.elb.amazonaws.com:9094"
     topic: app_logs_topic
     encoding:
       codec: json
+    sasl:
+      enabled: true
+      username: "vector-user"
+      password: "vector-password" # Ensure this EXACTLY matches the password in CDK/Helm
+      mechanism: "PLAIN"
 
   console:
     type: console

--- a/unilogs-cdk/.gitignore
+++ b/unilogs-cdk/.gitignore
@@ -9,6 +9,7 @@ destroy.sh
 launch.sh
 diff.sh
 examine-cluster.sh
+vector_data
 
 # CDK asset staging directory
 .cdk.staging

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -188,7 +188,6 @@ export class UnilogsCdkStack extends cdk.Stack {
             size: '10Gi',
             accessModes: ['ReadWriteOnce'],
           },
-          // REMOVED SASL CONFIGURATION
         },
 
         broker: {
@@ -221,20 +220,13 @@ export class UnilogsCdkStack extends cdk.Stack {
           },
         },
 
-        // REMOVED ALL SECURITY CONFIGURATION
         sasl: {
           // Define allowed mechanisms for clients connecting via SASL listeners
           enabledMechanisms: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512', // Include PLAIN
-          // Define users/passwords for the CLIENT listener (or external if specifically configured)
-          // NOTE: The Bitnami chart applies sasl.client credentials primarily to the listener named 'CLIENT' or if SASL is enabled there.
-          // Since your external listener uses SASL_PLAINTEXT, Kafka needs these credentials configured.
           client: {
             users: ['vector-user'],
             passwords: ['vector-password'], // Ensure this matches Vector's config
           },
-          // You might need inter-broker/controller credentials if those listeners use SASL too
-          // interBrokerMechanism: "PLAIN", // if listeners.interbroker.protocol uses SASL
-          // controllerMechanism: "PLAIN",  // if listeners.controller.protocol uses SASL
         },
 
         defaultInitContainers: {
@@ -537,7 +529,6 @@ export class UnilogsCdkStack extends cdk.Stack {
               bootstrap_servers: 'kafka.kafka.svc.cluster.local:9092',
               topics: ['app_logs_topic'],
               group_id: 'vector-consumer',
-              // REMOVED SASL CONFIGURATION
             },
           },
           transforms: {

--- a/vector_data/app_logs/checkpoints.json
+++ b/vector_data/app_logs/checkpoints.json
@@ -1,1 +1,1 @@
-{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":14718195932244085485},"position":168324,"modified":"2025-04-10T21:58:11.815886054Z"}]}
+{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":15800301865809783892},"position":945184,"modified":"2025-04-11T01:21:08.470456Z"}]}

--- a/vector_data/app_logs/checkpoints.json
+++ b/vector_data/app_logs/checkpoints.json
@@ -1,1 +1,1 @@
-{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":15800301865809783892},"position":945184,"modified":"2025-04-11T01:21:08.470456Z"}]}
+{"version":"1","checkpoints":[{"fingerprint":{"first_lines_checksum":15800301865809783892},"position":955474,"modified":"2025-04-11T01:25:38.591874Z"}]}


### PR DESCRIPTION
# Summary
- Removed kafka namespace
- Added SASL_PLAIN to vector shipper
- Added SASL_PLAIN to Kafka
- Removed controller from kafka external access config
- Removed autodiscovery from external access config (redundant)
## Instructions
- Make sure that vector shipper user name and password align with the ones defined in kafka config. For now they are `username: "vector-user"`
`password: "vector-password"`
- Make sure you're using correct bootstrap servers
- Can use this command to see incoming logs in realtime in Kafka
`kubectl exec -n kafka kafka-controller-0 -c kafka -- \
  [kafka-console-consumer.sh](http://kafka-console-consumer.sh/) \
    --bootstrap-server localhost:9092 \
    --topic app_logs_topic`
## Things to work on
- Adding TLS?
- Adding Secrets Manager so usernames and passwords aren't hardcoded