### PR TITLE
fix: added resources config values to limit Vector instances

### DIFF
--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -571,6 +571,16 @@ export class UnilogsCdkStack extends cdk.Stack {
       values: {
         role: 'Aggregator',
         autoscaling: { enabled: true }, // 1-10 pods
+        resources: {
+          requests: {
+            cpu: '200m',
+            memory: '256Mi'
+          },
+          limits: {
+            cpu: '200m',
+            memory: '256Mi'
+          },
+        },
         service: {
           // Add this section
           enabled: true,

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -158,7 +158,7 @@ export class UnilogsCdkStack extends cdk.Stack {
         new ec2.InstanceType('t3.large'), // Smaller instance (originally m5.large) for dev
       ],
       minSize: 2,
-      maxSize: 5,
+      maxSize: 50, // large maximum to avoid any limitation due to insufficient resources
       desiredSize: 2,
       diskSize: 30, // reduced from 50 GB for dev
       amiType: eks.NodegroupAmiType.AL2_X86_64,


### PR DESCRIPTION
# Avoiding the risk of overwhelming Loki by pulling from Kafka too quickly

Previously resource limits for Vector instances were not set, and the Vector documentation says it scales vertically automatically to consume all available vCPUs by default. Throughput per vCPU is ~25MB/s for structured log events (our logs are structured by the time they reach the Vector consumers subscribed to the Kafka topic). That means 2.16 TB/day per vCPU. Therefore, I used the example resource limits from the helm chart `values.yaml` file, reducing the resource limit of each Vector instance to 200m (20% of a vCPU), meaning that the maximum throughput when autoscaled to all 10 instances would be ~4.32 TB/day. Given that Loki can only handle "several" TB/day in log ingestion using the settings for "simple scalable" mode, this seems like a good maximum that doesn't require specifying a lower limit for the maximum instances, minimizing the changes to the config.