### PR TITLE
fix: writing successfully to s3 buckets

### DIFF
--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -378,11 +378,10 @@ export class UnilogsCdkStack extends cdk.Stack {
       'loki:loki-service-account'
     );
     const lokiRole = new iam.Role(this, 'LokiRole', {
-      assumedBy: new iam.WebIdentityPrincipal(
+      assumedBy: new iam.FederatedPrincipal(
         cluster.openIdConnectProvider.openIdConnectProviderArn,
-        {
-          StringEquals: lokiCondition,
-        }
+        {StringEquals: lokiCondition},
+        'sts:AssumeRoleWithWebIdentity'
       ),
       inlinePolicies: {
         lokiS3Access: new iam.PolicyDocument({
@@ -429,11 +428,16 @@ export class UnilogsCdkStack extends cdk.Stack {
               },
             ],
           },
-          storage_config: {
-            aws: {
+          storage: {
+            type: 's3',
+            bucketNames: {
+              chunks: lokiChunkBucket.bucketName,
+              ruler: lokiRulerBucket.bucketName,
+            },
+            s3: {
               region: this.region,
-              s3: lokiChunkBucket.bucketName,
-              s3forcepathstyle: false,
+              s3ForcePathStyle: false,
+              insecure: false,
             },
           },
           ingester: {

--- a/unilogs-cdk/lib/unilogs-cdk-stack.ts
+++ b/unilogs-cdk/lib/unilogs-cdk-stack.ts
@@ -14,7 +14,8 @@ export class UnilogsCdkStack extends cdk.Stack {
 
     // Helper function for IAM conditions
     const createConditionJson = (id: string, serviceAccount: string) => {
-      const issuerUrl = cluster.clusterOpenIdConnectIssuerUrl;
+      // const issuerUrl = cluster.clusterOpenIdConnectIssuerUrl;
+      const issuerUrl = cluster.openIdConnectProvider.openIdConnectProviderIssuer;
       if (!issuerUrl) {
         throw new Error('Cluster OIDC issuer URL is not available');
       }


### PR DESCRIPTION
This fixes the way we create the lokiRole so that it can be assumed by the loki-service-account and enables us to write to S3.

To test:

1. Just deploy it, start shipping logs, and then look at your S3 bucket and you'll see chunks!

<img width="934" alt="Screenshot 2025-04-18 at 5 58 23 PM" src="https://github.com/user-attachments/assets/406d0e70-79ce-4d3e-b8ea-b770c42248e1" />
